### PR TITLE
Compat with distributed 2.0

### DIFF
--- a/{{cookiecutter.project_slug}}/.dask/config.yaml
+++ b/{{cookiecutter.project_slug}}/.dask/config.yaml
@@ -20,7 +20,7 @@ kubernetes:
           - dask-worker
           - --nthreads
           - '2'
-          - --no-bokeh
+          - --no-dashboard
           - --memory-limit
           - 7GB
           - --death-timeout


### PR DESCRIPTION
--no-bokeh option renamed to --no-dashboard