### PR TITLE
Update to work with JupyterLab 1.0+ and new dask extensions

### DIFF
--- a/{{cookiecutter.project_slug}}/binder/environment.yml
+++ b/{{cookiecutter.project_slug}}/binder/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.6
+  - pip
   - xarray
   - dask
   - distributed
@@ -15,14 +16,15 @@ dependencies:
   - python-blosc
   - lz4
   - nomkl
-  - nbserverproxy
+  - jupyter-server-proxy
   - jupyter
-  - jupyterlab=0.35
+  - jupyterlab
   - jupyterlab_launcher
   - jupyter_client
   - ipywidgets
   - graphviz
   - nodejs
+  - dask-labextension
   - pip:
     - kubernetes
     - graphviz

--- a/{{cookiecutter.project_slug}}/binder/postBuild
+++ b/{{cookiecutter.project_slug}}/binder/postBuild
@@ -1,7 +1,6 @@
 #!/bin/bash
-jupyter serverextension enable --py nbserverproxy --sys-prefix
+jupyter serverextension enable --py jupyter_server_proxy --sys-prefix
 jupyter labextension install @jupyter-widgets/jupyterlab-manager \
-                             @jupyterlab/hub-extension@0.12 \
                              @pyviz/jupyterlab_pyviz \
                              jupyter-leaflet \
                              dask-labextension

--- a/{{cookiecutter.project_slug}}/binder/start
+++ b/{{cookiecutter.project_slug}}/binder/start
@@ -3,10 +3,9 @@
 # Replace DASK_DASHBOARD_URL with the proxy location
 sed -i -e "s|DASK_DASHBOARD_URL|/user/${JUPYTERHUB_USER}/proxy/8787|g" binder/jupyterlab-workspace.json
 # Get the right workspace ID
-sed -i -e "s|WORKSPACE_ID|/user/${JUPYTERHUB_USER}/lab|g" binder/jupyterlab-workspace.json
+sed -i -e "s|WORKSPACE_ID|/lab|g" binder/jupyterlab-workspace.json
 
 # Import the workspace into JupyterLab
-jupyter lab workspaces import binder/jupyterlab-workspace.json \
-  --NotebookApp.base_url=user/${JUPYTERHUB_USER}
+jupyter lab workspaces import binder/jupyterlab-workspace.json
 
 exec "$@"


### PR DESCRIPTION
These are changes I needed to make to get my own repository working with JupyterLab 1.0+. The main things are fixing workspace importing which no longer needs the base URL to be included and updating to use jupyter-server-proxy and dask-labextension. Note I didn't actually test the extensions and dashboards, but I didn't receive any errors when jlab opened. If anything this can be used as a reference.

This was based on help from @ian-r-rose and @TomAugspurger.